### PR TITLE
feat: add dynamic filter options

### DIFF
--- a/App/api.py
+++ b/App/api.py
@@ -65,12 +65,15 @@ def login():
 @app.route('/products', methods=['GET'])
 def get_products():
     products = product_manager.get_all_products()
-    # Convert products to JSON serializable format
-    for p in products:
-        # Convert attributes dict to list of key-value pairs for JSON serialization
-        if 'attributes' in p and isinstance(p['attributes'], dict):
-            p['attributes'] = [{'type': k, 'value': v} for k, vals in p['attributes'].items() for v in vals]
     return jsonify(products)
+
+@app.route('/filter-options', methods=['GET'])
+def get_filter_options():
+    category = request.args.get('category')
+    if not category:
+        return jsonify({'error': 'Missing category'}), 400
+    options = product_manager.get_filter_options(category)
+    return jsonify(options)
 
 @app.route('/orders', methods=['GET'])
 def get_orders():

--- a/App/database.py
+++ b/App/database.py
@@ -85,7 +85,67 @@ class Database:
                     FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
                 )
             ''')
-            
+
+            # Table of available filter keys for each category
+            self.cursor.execute('''
+                CREATE TABLE IF NOT EXISTS filter_keys (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    category ENUM('cake', 'food', 'drink') NOT NULL,
+                    filter_type VARCHAR(50) NOT NULL,
+                    filter_value VARCHAR(255) NOT NULL
+                )
+            ''')
+
+            # Seed default filter keys if none exist
+            self.cursor.execute('SELECT COUNT(*) FROM filter_keys')
+            if self.cursor.fetchone()[0] == 0:
+                default_keys = {
+                    'cake': {
+                        'occasion': [
+                            'Sinh nhật',
+                            'Đám cưới / hỏi',
+                            'Lễ tình nhân / Kỷ niệm',
+                            'Lễ hội',
+                            'Tặng đối tác / doanh nghiệp',
+                            'Khác'
+                        ],
+                        'flavor': [
+                            'Kem bơ',
+                            'Kem tươi',
+                            'Mousse',
+                            'Tiramisu',
+                            'Bánh kem lạnh'
+                        ],
+                        'ingredient': [
+                            'Trái cây tươi',
+                            'Socola',
+                            'Phô mai / cream cheese',
+                            'Trà xanh / matcha',
+                            'Các loại hạt'
+                        ],
+                        'size': [
+                            'Mini (1 người)',
+                            'Nhỏ – Trung bình (2-4 người)',
+                            'Lớn (trên 6 người)',
+                            'Nhiều tầng',
+                            'Hình dạng đặc biệt'
+                        ]
+                    },
+                    'food': {
+                        'type': ['Mì', 'Bánh', 'Pizza', 'Snack', 'Đồ chiên']
+                    },
+                    'drink': {
+                        'type': ['Nước ngọt', 'Nước ép trái cây', 'Trà sữa', 'Cà phê', 'Sinh tố']
+                    }
+                }
+                for category, filters in default_keys.items():
+                    for f_type, values in filters.items():
+                        for value in values:
+                            self.cursor.execute(
+                                'INSERT INTO filter_keys (category, filter_type, filter_value) VALUES (%s, %s, %s)',
+                                (category, f_type, value)
+                            )
+
             # Create orders table
             self.cursor.execute('''
                 CREATE TABLE IF NOT EXISTS orders (

--- a/App/tests/test_product_manager.py
+++ b/App/tests/test_product_manager.py
@@ -54,9 +54,9 @@ def test_add_product_with_attributes(product_manager):
     assert product is not None
     assert product['name'] == "Test Cake"
     assert product['category'] == "cake"
-    assert 'attributes' in product
-    assert 'Birthday' in product['attributes']['occasion']
-    assert 'Chocolate' in product['attributes']['flavor']
+    assert 'filters' in product
+    assert 'Birthday' in product['filters']['occasion']
+    assert 'Chocolate' in product['filters']['flavor']
 
 def test_delete_product(product_manager):
     # Add a product to delete
@@ -123,5 +123,5 @@ def test_get_products_by_category(product_manager):
 
 def test_get_filter_options(product_manager):
     options = product_manager.get_filter_options('cake')
-    assert 'socola' in options
-    assert 'khuyến mãi' in options
+    assert 'flavor' in options
+    assert 'Kem bơ' in options['flavor']

--- a/src/services/filterService.ts
+++ b/src/services/filterService.ts
@@ -1,0 +1,9 @@
+export const filterService = {
+    async getOptions(category: string): Promise<Record<string, string[]>> {
+        const response = await fetch(`http://localhost:5000/filter-options?category=${category}`);
+        if (!response.ok) {
+            throw new Error('Failed to fetch filter options');
+        }
+        return response.json();
+    }
+};

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -28,11 +28,7 @@ class ProductService {
                 image: p.image_url || '/images/default-product.jpg',
                 category: p.category.toLowerCase(), // Đảm bảo category được chuyển thành chữ thường
                 rating: p.rating || 0,
-                filters: p.attributes ? p.attributes.reduce((acc: any, attr: any) => {
-                    if (!acc[attr.type]) acc[attr.type] = [];
-                    acc[attr.type].push(attr.value);
-                    return acc;
-                }, {}) : {},
+                filters: p.filters || {},
                 inStock: p.quantity > 0,
                 onSale: false,
                 salePrice: null,


### PR DESCRIPTION
## Summary
- add `filter_keys` table with default values and expose `/filter-options` endpoint
- use dynamic filter options in frontend via new service
- adjust product manager and tests for filter retrieval

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `cd App && pytest` *(fails: Can't connect to MySQL server on 'localhost:3306')*

------
https://chatgpt.com/codex/tasks/task_e_6898b76c4c80832e9e37201890407a69