### PR TITLE
feat: support product filtering

### DIFF
--- a/App/api.py
+++ b/App/api.py
@@ -4,6 +4,7 @@ from order_manager import OrderManager
 from flask_cors import CORS
 import mysql.connector
 import hashlib
+import json
 
 app = Flask(__name__)
 CORS(app)  # Enable CORS for frontend requests
@@ -64,7 +65,15 @@ def login():
 
 @app.route('/products', methods=['GET'])
 def get_products():
-    products = product_manager.get_all_products()
+    category = request.args.get('category')
+    filters_param = request.args.get('filters')
+    filters = None
+    if filters_param:
+        try:
+            filters = json.loads(filters_param)
+        except (TypeError, ValueError):
+            filters = None
+    products = product_manager.get_all_products(category, filters)
     return jsonify(products)
 
 @app.route('/filter-options', methods=['GET'])

--- a/App/tests/test_product_manager.py
+++ b/App/tests/test_product_manager.py
@@ -119,9 +119,39 @@ def test_get_products_by_category(product_manager):
     assert any(p['name'] == "Test Food 1" for p in foods)
     assert all(p['category'] == "cake" for p in cakes)
     assert all(p['category'] == "food" for p in foods)
-
+    
 
 def test_get_filter_options(product_manager):
     options = product_manager.get_filter_options('cake')
     assert 'flavor' in options
     assert 'Kem bơ' in options['flavor']
+
+
+def test_get_products_with_multiple_filters(product_manager):
+    attributes = {
+        'flavor': ['Chocolate'],
+        'occasion': ['Birthday']
+    }
+
+    product_manager.add_product(
+        name="Chocolate Birthday Cake",
+        price=350.00,
+        category="cake",
+        attributes=attributes
+    )
+
+    product_manager.add_product(
+        name="Vanilla Wedding Cake",
+        price=400.00,
+        category="cake",
+        attributes={
+            'flavor': ['Vanilla'],
+            'occasion': ['Wedding']
+        }
+    )
+
+    filters = {'flavor': 'Chocolate', 'occasion': 'Birthday'}
+    results = product_manager.get_all_products('cake', filters)
+
+    assert len(results) == 1
+    assert results[0]['name'] == "Chocolate Birthday Cake"

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -12,9 +12,17 @@ class ProductService {
         price: null
     };
 
-    async loadProducts(): Promise<void> {
+    async loadProducts(category?: string, filters: Record<string, any> = {}): Promise<void> {
         try {
-            const response = await fetch('http://localhost:5000/products');
+            const params = new URLSearchParams();
+            if (category) {
+                params.append('category', category);
+            }
+            if (filters && Object.keys(filters).length > 0) {
+                params.append('filters', JSON.stringify(filters));
+            }
+            const url = `http://localhost:5000/products${params.toString() ? `?${params.toString()}` : ''}`;
+            const response = await fetch(url);
             if (!response.ok) {
                 throw new Error('Failed to fetch products from backend');
             }


### PR DESCRIPTION
## Summary
- allow `/products` endpoint to accept `category` and `filters` query params
- request filtered products from the frontend using these query params
- cover retrieving products with multiple filters in ProductManager tests

## Testing
- `pytest App/tests/test_product_manager.py::test_get_products_with_multiple_filters -q` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68a45e707490832e88b546834d7f54f4